### PR TITLE
set plugin logger to debug instead of info

### DIFF
--- a/hooks/tk-multi-launchapp/before_app_launch.py
+++ b/hooks/tk-multi-launchapp/before_app_launch.py
@@ -156,7 +156,7 @@ class BeforeAppLaunch(sgtk.Hook):
                 self.__max_check(app_version, result.get('sg_host_max_version'))
             ):
                 try:
-                    self.logger.info("[CBFX] Valid plugin found: {}".format(result.get('code')))
+                    self.logger.debug("[CBFX] Valid plugin found: {}".format(result.get('code')))
                     env_list.extend(result.get(os_envs[sys.platform]).split('\n'))
                 except AttributeError as e:
                     self.logger.error('AttributeError on plugin \'{}\': {}'.format(result.get('code'), e))


### PR DESCRIPTION
- was causing a pop up when lunching software from webbrowser
- made this logging debug rather than info