### PR TITLE
updated ocio config

### DIFF
--- a/core/schema/project/pipeline/color/config.ocio
+++ b/core/schema/project/pipeline/color/config.ocio
@@ -1,6 +1,6 @@
 ocio_profile_version: 1
 
-search_path: ${OCIO_CONFIGS}/aces_1.0.3/luts:${OCIO_CONFIGS}/nuke-default/luts:../../shots/$SEQ/luts:../../shots/$SEQ/$SHOT/luts:luts
+search_path: ./:${OCIO_CONFIGS}/aces_1.0.3/luts:${OCIO_CONFIGS}/nuke-default/luts:../../shots/$SEQ/luts:../../shots/$SEQ/$SHOT/luts:luts
 strictparsing: true
 luma: [0.2126, 0.7152, 0.0722]
 


### PR DESCRIPTION
- added current path to search path
- seems to search this path anyway but without a : before the
${OCIO_CONFIGS} some dccs (MAYA! it was MAYA) were concatinating the
paths incorrectly